### PR TITLE
chore: upgrade language configurations

### DIFF
--- a/grammars/css/language-configuration.json
+++ b/grammars/css/language-configuration.json
@@ -26,5 +26,10 @@
 			"start": "^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/",
 			"end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
 		}
-	}
+	},
+	"indentationRules": {
+		"increaseIndentPattern": "(^.*\\{[^}]*$)",
+		"decreaseIndentPattern": "^\\s*\\}"
+	},
+	"wordPattern": "(#?-?\\d*\\.\\d\\w*%?)|(::?[\\w-]*(?=[^,{;]*[,{]))|(([@#.!])?[\\w-?]+%?|[@#!.])"
 }

--- a/grammars/html/language-configuration.json
+++ b/grammars/html/language-configuration.json
@@ -29,5 +29,31 @@
 			"start": "^\\s*<!--\\s*#region\\b.*-->",
 			"end": "^\\s*<!--\\s*#endregion\\b.*-->"
 		}
+	},
+	"wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\$\\^\\&\\*\\(\\)\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\s]+)",
+	"onEnterRules": [
+		{
+			"beforeText": {
+				"pattern": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))([_:\\w][_:\\w-.\\d]*)([^/>]*(?!\\/)>)[^<]*$",
+				"flags": "i"
+			},
+			"afterText": { "pattern": "^<\\/([_:\\w][_:\\w-.\\d]*)\\s*>", "flags": "i" },
+			"action": {
+				"indent": "indentOutdent"
+			}
+		},
+		{
+			"beforeText": {
+				"pattern": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))(\\w[\\w\\d]*)([^/>]*(?!\\/)>)[^<]*$",
+				"flags": "i"
+			},
+			"action": {
+				"indent": "indent"
+			}
+		}
+	],
+	"indentationRules": {
+		"increaseIndentPattern": "<(?!\\?|(?:area|base|br|col|frame|hr|html|img|input|keygen|link|menuitem|meta|param|source|track|wbr)\\b|[^>]*\\/>)([-_\\.A-Za-z0-9]+)(?=\\s|>)\\b[^>]*>(?!.*<\\/\\1>)|<!--(?!.*-->)|\\{[^}\"']*$",
+		"decreaseIndentPattern": "^\\s*(<\\/(?!html)[-_\\.A-Za-z0-9]+\\b[^>]*>|-->|\\})"
 	}
 }

--- a/grammars/json/language-configuration.json
+++ b/grammars/json/language-configuration.json
@@ -14,5 +14,10 @@
 		{ "open": "'", "close": "'", "notIn": ["string"] },
 		{ "open": "\"", "close": "\"", "notIn": ["string", "comment"] },
 		{ "open": "`", "close": "`", "notIn": ["string", "comment"] }
-	]
+	],
+	"wordPattern": "(\"(?:[^\\\\\\\"]*(?:\\\\.)?)*\"?)|[^\\s{}\\[\\],:]+",
+	"indentationRules": {
+		"increaseIndentPattern": "({+(?=([^\"]*\"[^\"]*\")*[^\"}]*$))|(\\[+(?=([^\"]*\"[^\"]*\")*[^\"\\]]*$))",
+		"decreaseIndentPattern": "^\\s*[}\\]],?\\s*$"
+	}
 }

--- a/grammars/less/language-configuration.json
+++ b/grammars/less/language-configuration.json
@@ -22,14 +22,15 @@
 		["\"", "\""],
 		["'", "'"]
 	],
-	"indentationRules": {
-		"increaseIndentPattern": "(^.*\\{[^}]*$)",
-		"decreaseIndentPattern": "^\\s*\\}"
-	},
 	"folding": {
 		"markers": {
 			"start": "^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/",
 			"end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
 		}
-	}
+	},
+	"indentationRules": {
+		"increaseIndentPattern": "(^.*\\{[^}]*$)",
+		"decreaseIndentPattern": "^\\s*\\}"
+	},
+	"wordPattern": "(#?-?\\d*\\.\\d\\w*%?)|(::?[\\w-]+(?=[^,{;]*[,{]))|(([@#.!])?[\\w-?]+%?|[@#!.])"
 }

--- a/grammars/scss/language-configuration.json
+++ b/grammars/scss/language-configuration.json
@@ -27,5 +27,10 @@
 			"start": "^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/",
 			"end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
 		}
-	}
+	},
+	"indentationRules": {
+		"increaseIndentPattern": "(^.*\\{[^}]*$)",
+		"decreaseIndentPattern": "^\\s*\\}"
+	},
+	"wordPattern": "(#?-?\\d*\\.\\d\\w*%?)|(::?[\\w-]*(?=[^,{;]*[,{]))|(([@$#.!])?[\\w-?]+%?|[@#!$.])"
 }


### PR DESCRIPTION
I went over the language configurations and updated them based on what VSCode uses nowadays.

All the added `indentationRules` and `wordPattern` expressions will fix auto-indenting and auto-surrounding for those languages like CSS/HTML/...