### PR TITLE
feat(angular): add angular syntax highlighting

### DIFF
--- a/grammars/angular/syntaxes/expression.json
+++ b/grammars/angular/syntaxes/expression.json
@@ -1,0 +1,834 @@
+{
+	"scopeName": "expression.ng",
+	"injectionSelector": "L:text.html -comment",
+	"patterns": [
+		{
+			"include": "#ngExpression"
+		}
+	],
+	"repository": {
+		"ngExpression": {
+			"name": "meta.expression.ng",
+			"patterns": [
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#literal"
+				},
+				{
+					"include": "#ternaryExpression"
+				},
+				{
+					"include": "#expressionOperator"
+				},
+				{
+					"include": "#functionCall"
+				},
+				{
+					"include": "#identifiers"
+				},
+				{
+					"include": "#parenExpression"
+				},
+				{
+					"include": "#punctuationComma"
+				},
+				{
+					"include": "#punctuationAccessor"
+				}
+			]
+		},
+		"arrayLiteral": {
+			"name": "meta.array.literal.ts",
+			"begin": "\\[",
+			"beginCaptures": {
+				"0": {
+					"name": "meta.brace.square.ts"
+				}
+			},
+			"end": "\\]",
+			"endCaptures": {
+				"0": {
+					"name": "meta.brace.square.ts"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#ngExpression"
+				},
+				{
+					"include": "#punctuationComma"
+				}
+			]
+		},
+		"booleanLiteral": {
+			"patterns": [
+				{
+					"name": "constant.language.boolean.true.ts",
+					"match": "(?<!\\.|\\$)\\btrue\\b(?!\\$)"
+				},
+				{
+					"name": "constant.language.boolean.false.ts",
+					"match": "(?<!\\.|\\$)\\bfalse\\b(?!\\$)"
+				}
+			]
+		},
+		"expressionOperator": {
+			"patterns": [
+				{
+					"match": "((?<!\\|)\\|(?!\\|))\\s?([a-zA-Z0-9\\-\\_\\$]*)",
+					"captures": {
+						"1": {
+							"name": "keyword.operator.logical.ts"
+						},
+						"2": {
+							"name": "entity.name.function.pipe.ng"
+						}
+					}
+				},
+				{
+					"name": "storage.type.ts",
+					"match": "(?<!\\.|\\$)\\b(let)\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.control.flow.ts",
+					"match": "(?<!\\.|\\$)\\b(await)\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.operator.expression.delete.ts",
+					"match": "(?<!\\.|\\$)\\bdelete\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.operator.expression.in.ts",
+					"match": "(?<!\\.|\\$)\\bin\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.operator.expression.of.ts",
+					"match": "(?<!\\.|\\$)\\bof\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.control.if.ts",
+					"match": "(?<!\\.|\\$)\\bif\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.control.else.ts",
+					"match": "(?<!\\.|\\$)\\belse\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.control.then.ts",
+					"match": "(?<!\\.|\\$)\\bthen\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.operator.expression.instanceof.ts",
+					"match": "(?<!\\.|\\$)\\binstanceof\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.operator.new.ts",
+					"match": "(?<!\\.|\\$)\\bnew\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.operator.expression.void.ts",
+					"match": "(?<!\\.|\\$)\\bvoid\\b(?!\\$)"
+				},
+				{
+					"begin": "(?<!\\.|\\$)\\bas\\b(?!\\$)",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.as.ts"
+						}
+					},
+					"end": "(?=$|\"|[;,:})\\]])",
+					"patterns": [
+						{
+							"include": "#type"
+						}
+					]
+				},
+				{
+					"name": "keyword.operator.assignment.compound.ts",
+					"match": "\\*=|(?<!\\()\\/=|%=|\\+=|\\-="
+				},
+				{
+					"name": "keyword.operator.assignment.compound.bitwise.ts",
+					"match": "\\&=|\\^=|<<=|>>=|>>>=|\\|="
+				},
+				{
+					"name": "keyword.operator.bitwise.shift.ts",
+					"match": "<<|>>>|>>"
+				},
+				{
+					"name": "keyword.operator.comparison.ts",
+					"match": "===|!==|==|!="
+				},
+				{
+					"name": "keyword.operator.relational.ts",
+					"match": "<=|>=|<>|<|>"
+				},
+				{
+					"name": "keyword.operator.logical.ts",
+					"match": "\\!|&&|\\?\\?|\\|\\|"
+				},
+				{
+					"name": "keyword.operator.bitwise.ts",
+					"match": "\\&|~|\\^|\\|"
+				},
+				{
+					"name": "keyword.operator.assignment.ts",
+					"match": "\\="
+				},
+				{
+					"name": "keyword.operator.decrement.ts",
+					"match": "--"
+				},
+				{
+					"name": "keyword.operator.increment.ts",
+					"match": "\\+\\+"
+				},
+				{
+					"name": "keyword.operator.arithmetic.ts",
+					"match": "\\%|\\*|\\/|-|\\+"
+				},
+				{
+					"match": "(?<=[_$[:alnum:]])\\s*(\\/)(?![\\/*])",
+					"captures": {
+						"1": {
+							"name": "keyword.operator.arithmetic.ts"
+						}
+					}
+				},
+				{
+					"include": "#typeofOperator"
+				}
+			]
+		},
+		"functionCall": {
+			"begin": "(?=(\\??\\.\\s*)?([_$[:alpha:]][_$[:alnum:]]*)\\s*(<([^<>]|\\<[^<>]+\\>)+>\\s*)?\\()",
+			"end": "(?<=\\))(?!(\\??\\.\\s*)?([_$[:alpha:]][_$[:alnum:]]*)\\s*(<([^<>]|\\<[^<>]+\\>)+>\\s*)?\\()",
+			"patterns": [
+				{
+					"name": "punctuation.accessor.ts",
+					"match": "\\?"
+				},
+				{
+					"name": "punctuation.accessor.ts",
+					"match": "\\."
+				},
+				{
+					"name": "entity.name.function.ts",
+					"match": "([_$[:alpha:]][_$[:alnum:]]*)"
+				},
+				{
+					"name": "meta.type.parameters.ts",
+					"begin": "\\<",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.typeparameters.begin.ts"
+						}
+					},
+					"end": "\\>",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.typeparameters.end.ts"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#type"
+						},
+						{
+							"include": "#punctuationComma"
+						}
+					]
+				},
+				{
+					"include": "#parenExpression"
+				}
+			]
+		},
+		"functionParameters": {
+			"name": "meta.parameters.ts",
+			"begin": "\\(",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.parameters.begin.ts"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.parameters.end.ts"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#decorator"
+				},
+				{
+					"include": "#parameterName"
+				},
+				{
+					"include": "#variableInitializer"
+				},
+				{
+					"name": "punctuation.separator.parameter.ts",
+					"match": ","
+				}
+			]
+		},
+		"identifiers": {
+			"patterns": [
+				{
+					"name": "support.class.ts",
+					"match": "([_$[:alpha:]][_$[:alnum:]]*)(?=\\s*\\.\\s*prototype\\b(?!\\$))"
+				},
+				{
+					"match": "(?x)([?!]?\\.)\\s*(?:\n([[:upper:]][_$[:digit:][:upper:]]*)|\n([_$[:alpha:]][_$[:alnum:]]*)\n)(?=\\s*\\.\\s*[_$[:alpha:]][_$[:alnum:]]*)",
+					"captures": {
+						"1": {
+							"name": "punctuation.accessor.ts"
+						},
+						"2": {
+							"name": "constant.other.object.property.ts"
+						},
+						"3": {
+							"name": "variable.other.object.property.ts"
+						}
+					}
+				},
+				{
+					"match": "(?x)(?:([?!]?\\.)\\s*)?([_$[:alpha:]][_$[:alnum:]]*)(?=\\s*=\\s*((async\\s+)|(function\\s*[(<])|(function\\s+)|([_$[:alpha:]][_$[:alnum:]]*\\s*=>)|((<([^<>]|\\<[^<>]+\\>)+>\\s*)?\\(([^()]|\\([^()]*\\))*\\)(\\s*:\\s*(.)*)?\\s*=>)))",
+					"captures": {
+						"1": {
+							"name": "punctuation.accessor.ts"
+						},
+						"2": {
+							"name": "entity.name.function.ts"
+						}
+					}
+				},
+				{
+					"match": "([?!]?\\.)\\s*([[:upper:]][_$[:digit:][:upper:]]*)(?![_$[:alnum:]])",
+					"captures": {
+						"1": {
+							"name": "punctuation.accessor.ts"
+						},
+						"2": {
+							"name": "constant.other.property.ts"
+						}
+					}
+				},
+				{
+					"match": "([?!]?\\.)\\s*([_$[:alpha:]][_$[:alnum:]]*)",
+					"captures": {
+						"1": {
+							"name": "punctuation.accessor.ts"
+						},
+						"2": {
+							"name": "variable.other.property.ts"
+						}
+					}
+				},
+				{
+					"match": "(?x)(?:\n([[:upper:]][_$[:digit:][:upper:]]*)|\n([_$[:alpha:]][_$[:alnum:]]*)\n)(?=\\s*\\.\\s*[_$[:alpha:]][_$[:alnum:]]*)",
+					"captures": {
+						"1": {
+							"name": "constant.other.object.ts"
+						},
+						"2": {
+							"name": "variable.other.object.ts"
+						}
+					}
+				},
+				{
+					"name": "constant.character.other",
+					"match": "([[:upper:]][_$[:digit:][:upper:]]*)(?![_$[:alnum:]])"
+				},
+				{
+					"name": "variable.other.readwrite.ts",
+					"match": "[_$[:alpha:]][_$[:alnum:]]*"
+				}
+			]
+		},
+		"literal": {
+			"name": "literal.ts",
+			"patterns": [
+				{
+					"include": "#numericLiteral"
+				},
+				{
+					"include": "#booleanLiteral"
+				},
+				{
+					"include": "#nullLiteral"
+				},
+				{
+					"include": "#undefinedLiteral"
+				},
+				{
+					"include": "#numericConstantLiteral"
+				},
+				{
+					"include": "#arrayLiteral"
+				},
+				{
+					"include": "#thisLiteral"
+				}
+			]
+		},
+		"nullLiteral": {
+			"name": "constant.language.null.ts",
+			"match": "(?<!\\.|\\$)\\bnull\\b(?!\\$)"
+		},
+		"numericLiteral": {
+			"patterns": [
+				{
+					"name": "constant.numeric.hex.ts",
+					"match": "\\b(?<!\\$)0(x|X)[0-9a-fA-F]+\\b(?!\\$)"
+				},
+				{
+					"name": "constant.numeric.binary.ts",
+					"match": "\\b(?<!\\$)0(b|B)[01]+\\b(?!\\$)"
+				},
+				{
+					"name": "constant.numeric.octal.ts",
+					"match": "\\\\b(?<!\\$)0(o|O)?[0-7]+\\b(?!\\$)"
+				},
+				{
+					"match": "(?x)\n(?<!\\$)(?:\n(?:\\b[0-9]+(\\.)[0-9]+[eE][+-]?[0-9]+\\b)|#1.1E+3\n(?:\\b[0-9]+(\\.)[eE][+-]?[0-9]+\\b)|#1.E+3\n(?:\\B(\\.)[0-9]+[eE][+-]?[0-9]+\\b)|#.1E+3\n(?:\\b[0-9]+[eE][+-]?[0-9]+\\b)|#1E+3(?:\\b[0-9]+(\\.)[0-9]+\\b)|#1.1\n(?:\\b[0-9]+(\\.)\\B)|#1.\n(?:\\B(\\.)[0-9]+\\b)|#.1\n (?:\\b[0-9]+\\b(?!\\.))#1\n)(?!\\$)",
+					"captures": {
+						"0": {
+							"name": "constant.numeric.decimal.ts"
+						},
+						"1": {
+							"name": "meta.delimiter.decimal.period.ts"
+						},
+						"2": {
+							"name": "meta.delimiter.decimal.period.ts"
+						},
+						"3": {
+							"name": "meta.delimiter.decimal.period.ts"
+						},
+						"4": {
+							"name": "meta.delimiter.decimal.period.ts"
+						},
+						"5": {
+							"name": "meta.delimiter.decimal.period.ts"
+						},
+						"6": {
+							"name": "meta.delimiter.decimal.period.ts"
+						}
+					}
+				}
+			]
+		},
+		"numericConstantLiteral": {
+			"patterns": [
+				{
+					"name": "constant.language.nan.ts",
+					"match": "(?<!\\.|\\$)\\bNaN\\b(?!\\$)"
+				},
+				{
+					"name": "constant.language.infinity.ts",
+					"match": "(?<!\\.|\\$)\\bInfinity\\b(?!\\$)"
+				}
+			]
+		},
+		"parameterName": {
+			"patterns": [
+				{
+					"match": "(?x)(?:\\s*\\b(readonly)\\s+)?(?:\\s*\\b(public|private|protected)\\s+)?(\\.\\.\\.)?\\s*(?<!=|:)([_$[:alpha:]][_$[:alnum:]]*)\\s*(\\??)(?=\\s* (=\\s*( (async\\s+) | (function\\s*[(<]) | (function\\s+) | ([_$[:alpha:]][_$[:alnum:]]*\\s*=>) | ((<([^<>]|\\<[^<>]+\\>)+>\\s*)?\\(([^()]|\\([^()]*\\))*\\)(\\s*:\\s*(.)*)?\\s*=>)) ) | (:\\s*( (<) | ([(]\\s*( ([)]) | (\\.\\.\\.) | ([_$[:alnum:]]+\\s*( ([:,?=])| ([)]\\s*=>) )) ))) ))",
+					"captures": {
+						"1": {
+							"name": "storage.modifier.ts"
+						},
+						"2": {
+							"name": "storage.modifier.ts"
+						},
+						"3": {
+							"name": "keyword.operator.rest.ts"
+						},
+						"4": {
+							"name": "entity.name.function.ts"
+						},
+						"5": {
+							"name": "keyword.operator.optional.ts"
+						}
+					}
+				},
+				{
+					"match": "(?:\\s*\\b(readonly)\\s+)?(?:\\s*\\b(public|private|protected)\\s+)?(\\.\\.\\.)?\\s*(?<!=|:)([_$[:alpha:]][_$[:alnum:]]*)\\s*(\\??)",
+					"captures": {
+						"1": {
+							"name": "storage.modifier.ts"
+						},
+						"2": {
+							"name": "storage.modifier.ts"
+						},
+						"3": {
+							"name": "keyword.operator.rest.ts"
+						},
+						"4": {
+							"name": "variable.parameter.ts"
+						},
+						"5": {
+							"name": "keyword.operator.optional.ts"
+						}
+					}
+				}
+			]
+		},
+		"parenExpression": {
+			"begin": "\\(",
+			"beginCaptures": {
+				"0": {
+					"name": "meta.brace.round.ts"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "meta.brace.round.ts"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#ngExpression"
+				},
+				{
+					"include": "#punctuationComma"
+				}
+			]
+		},
+		"punctuationAccessor": {
+			"name": "punctuation.accessor.ts",
+			"match": "\\?\\.|\\!\\.|\\."
+		},
+		"punctuationComma": {
+			"name": "punctuation.separator.comma.ts",
+			"match": ","
+		},
+		"punctuationSemicolon": {
+			"name": "punctuation.terminator.statement.ts",
+			"match": ";"
+		},
+		"qstringDouble": {
+			"name": "string.quoted.double.ts",
+			"begin": "\"",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.ts"
+				}
+			},
+			"end": "(\")|((?:[^\\\\\\n])$)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.ts"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.ts"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#stringCharacterEscape"
+				}
+			]
+		},
+		"qstringSingle": {
+			"name": "string.quoted.single.ts",
+			"begin": "'",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.ts"
+				}
+			},
+			"end": "(\\')|((?:[^\\\\\\n])$)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.ts"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.ts"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#stringCharacterEscape"
+				}
+			]
+		},
+		"stringCharacterEscape": {
+			"name": "constant.character.escape.ts",
+			"match": "\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)"
+		},
+		"ternaryExpression": {
+			"begin": "(?!\\?\\.\\s*[^[:digit:]])(\\?)(?!\\?)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.ternary.ts"
+				}
+			},
+			"end": "\\s*(:)",
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.ternary.ts"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#ngExpression"
+				}
+			]
+		},
+		"thisLiteral": {
+			"name": "variable.language.this.ts",
+			"match": "(?<!\\.|\\$)\\bthis\\b(?!\\$)"
+		},
+		"string": {
+			"patterns": [
+				{
+					"include": "#qstringSingle"
+				},
+				{
+					"include": "#qstringDouble"
+				}
+			]
+		},
+		"typeAnnotation": {
+			"name": "meta.type.annotation.ts",
+			"begin": ":",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.type.annotation.ts"
+				}
+			},
+			"end": "(?=$|[,);\\}\\]]|\\/\\/|\")|(?==[^>])|(?<=[\\}>\\]\\)]|[_$[:alpha:]])\\s*(?=\\{)",
+			"patterns": [
+				{
+					"include": "#type"
+				}
+			]
+		},
+		"typeBuiltinLiterals": {
+			"name": "support.type.builtin.ts",
+			"match": "(?<!\\.|\\$)\\b(this|true|false|undefined|null)\\b(?!\\$)"
+		},
+		"typeFnTypeParameters": {
+			"patterns": [
+				{
+					"name": "meta.type.constructor.ts",
+					"match": "(?<!\\.|\\$)\\b(new)\\b(?=\\s*\\<)",
+					"captures": {
+						"1": {
+							"name": "keyword.control.new.ts"
+						}
+					}
+				},
+				{
+					"name": "meta.type.constructor.ts",
+					"begin": "(?<!\\.|\\$)\\b(new)\\b\\s*(?=\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.new.ts"
+						}
+					},
+					"end": "(?<=\\))",
+					"patterns": [
+						{
+							"include": "#functionParameters"
+						}
+					]
+				},
+				{
+					"name": "meta.type.function.ts",
+					"include": "#typeofOperator",
+					"begin": "(?<=\\>)\\s*(?=\\()",
+					"end": "(?<=\\))",
+					"patterns": [
+						{
+							"include": "#functionParameters"
+						}
+					]
+				},
+				{
+					"name": "meta.type.function.ts",
+					"begin": "(?x)((?=[(]\\s*(([)])|(\\.\\.\\.)|([_$[:alnum:]]+\\s*(([:,?=])|([)]\\s*=>))))))",
+					"end": "(?<=\\))",
+					"patterns": [
+						{
+							"include": "#functionParameters"
+						}
+					]
+				}
+			]
+		},
+		"typeName": {
+			"patterns": [
+				{
+					"match": "([_$[:alpha:]][_$[:alnum:]]*)\\s*([?!]?\\.)",
+					"captures": {
+						"1": {
+							"name": "entity.name.type.module.ts"
+						},
+						"2": {
+							"name": "punctuation.accessor.ts"
+						}
+					}
+				},
+				{
+					"name": "entity.name.type.ts",
+					"match": "[_$[:alpha:]][_$[:alnum:]]*"
+				}
+			]
+		},
+		"typeObjectMembers": {
+			"patterns": [
+				{
+					"include": "#typeAnnotation"
+				},
+				{
+					"include": "#punctuationComma"
+				},
+				{
+					"include": "#punctuationSemicolon"
+				}
+			]
+		},
+		"typeObject": {
+			"name": "meta.object.type.ts",
+			"begin": "\\{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.ts"
+				}
+			},
+			"end": "\\}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.ts"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#typeObjectMembers"
+				}
+			]
+		},
+		"typeOperators": {
+			"patterns": [
+				{
+					"include": "#typeofOperator"
+				},
+				{
+					"name": "keyword.operator.type.ts",
+					"match": "[&|]"
+				},
+				{
+					"name": "keyword.operator.expression.keyof.ts",
+					"match": "(?<!\\.|\\$)\\bkeyof\\b(?!\\$)"
+				}
+			]
+		},
+		"typeParenOrFunctionParameters": {
+			"name": "meta.type.paren.cover.ts",
+			"begin": "\\(",
+			"beginCaptures": {
+				"0": {
+					"name": "meta.brace.round.ts"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "meta.brace.round.ts"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#type"
+				},
+				{
+					"include": "#functionParameters"
+				}
+			]
+		},
+		"typeTuple": {
+			"name": "meta.type.tuple.ts",
+			"begin": "\\[",
+			"beginCaptures": {
+				"0": {
+					"name": "meta.brace.square.ts"
+				}
+			},
+			"end": "\\]",
+			"endCaptures": {
+				"0": {
+					"name": "meta.brace.square.ts"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#type"
+				},
+				{
+					"include": "#punctuationComma"
+				}
+			]
+		},
+		"type": {
+			"name": "meta.type.ts",
+			"patterns": [
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#numericLiteral"
+				},
+				{
+					"include": "#typeBuiltinLiterals"
+				},
+				{
+					"include": "#typeTuple"
+				},
+				{
+					"include": "#typeObject"
+				},
+				{
+					"include": "#typeOperators"
+				},
+				{
+					"include": "#typeFnTypeParameters"
+				},
+				{
+					"include": "#typeParenOrFunctionParameters"
+				},
+				{
+					"include": "#typeName"
+				}
+			]
+		},
+		"typeofOperator": {
+			"name": "keyword.operator.expression.typeof.ts",
+			"match": "(?<!\\.|\\$)\\btypeof\\b(?!\\$)"
+		},
+		"undefinedLiteral": {
+			"name": "constant.language.undefined.ts",
+			"match": "(?<!\\.|\\$)\\bundefined\\b(?!\\$)"
+		},
+		"variableInitializer": {
+			"begin": "(?<!=|!)(=)(?!=)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.assignment.ts"
+				}
+			},
+			"end": "(?=$|[,);}\\]])",
+			"patterns": [
+				{
+					"include": "#ngExpression"
+				}
+			]
+		}
+	}
+}

--- a/grammars/angular/syntaxes/inline-styles.json
+++ b/grammars/angular/syntaxes/inline-styles.json
@@ -1,0 +1,98 @@
+{
+	"scopeName": "inline-styles.ng",
+	"injectionSelector": "L:source.ts#meta.decorator.ts -comment",
+	"patterns": [
+		{
+			"include": "#inlineStyles"
+		}
+	],
+	"repository": {
+		"inlineStyles": {
+			"begin": "(styles)\\s*(:)",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.object-literal.key.ts"
+				},
+				"2": {
+					"name": "meta.object-literal.key.ts punctuation.separator.key-value.ts"
+				}
+			},
+			"end": "(?=,|})",
+			"patterns": [
+				{
+					"include": "#tsParenExpression"
+				},
+				{
+					"include": "#tsBracketExpression"
+				},
+				{
+					"include": "#style"
+				}
+			]
+		},
+		"tsParenExpression": {
+			"begin": "\\G\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.brace.round.ts"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "meta.brace.round.ts"
+				}
+			},
+			"patterns": [
+				{
+					"include": "$self"
+				},
+				{
+					"include": "#tsBracketExpression"
+				},
+				{
+					"include": "#style"
+				}
+			]
+		},
+		"tsBracketExpression": {
+			"begin": "\\G\\s*(\\[)",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.array.literal.ts meta.brace.square.ts"
+				}
+			},
+			"end": "\\]",
+			"endCaptures": {
+				"0": {
+					"name": "meta.array.literal.ts meta.brace.square.ts"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#style"
+				}
+			]
+		},
+		"style": {
+			"begin": "\\s*([`|'|\"])",
+			"beginCaptures": {
+				"1": {
+					"name": "string"
+				}
+			},
+			"end": "\\1",
+			"endCaptures": {
+				"0": {
+					"name": "string"
+				}
+			},
+			"contentName": "source.css",
+			"patterns": [
+				{
+					"include": "source.css"
+				}
+			]
+		}
+	}
+}

--- a/grammars/angular/syntaxes/inline-template.json
+++ b/grammars/angular/syntaxes/inline-template.json
@@ -1,0 +1,76 @@
+{
+	"scopeName": "inline-template.ng",
+	"injectionSelector": "L:meta.decorator.ts -comment -text.html",
+	"patterns": [
+		{
+			"include": "#inlineTemplate"
+		}
+	],
+	"repository": {
+		"inlineTemplate": {
+			"begin": "(template)\\s*(:)",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.object-literal.key.ts"
+				},
+				"2": {
+					"name": "meta.object-literal.key.ts punctuation.separator.key-value.ts"
+				}
+			},
+			"end": "(?=,|})",
+			"patterns": [
+				{
+					"include": "#tsParenExpression"
+				},
+				{
+					"include": "#ngTemplate"
+				}
+			]
+		},
+		"tsParenExpression": {
+			"begin": "\\G\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.brace.round.ts"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "meta.brace.round.ts"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#tsParenExpression"
+				},
+				{
+					"include": "#ngTemplate"
+				}
+			]
+		},
+		"ngTemplate": {
+			"begin": "\\G\\s*([`|'|\"])",
+			"beginCaptures": {
+				"1": {
+					"name": "string"
+				}
+			},
+			"end": "\\1",
+			"endCaptures": {
+				"0": {
+					"name": "string"
+				}
+			},
+			"contentName": "text.html",
+			"patterns": [
+				{
+					"include": "text.html.derivative"
+				},
+				{
+					"include": "template.ng"
+				}
+			]
+		}
+	}
+}

--- a/grammars/angular/syntaxes/template-blocks.json
+++ b/grammars/angular/syntaxes/template-blocks.json
@@ -1,0 +1,83 @@
+{
+	"scopeName": "template.blocks.ng",
+	"injectionSelector": "L:text.html -comment -expression.ng -meta.tag",
+	"patterns": [
+		{
+			"include": "#block"
+		}
+	],
+	"repository": {
+		"transition": {
+			"match": "@",
+			"name": "keyword.control.block.transition.ng"
+		},
+		"block": {
+			"begin": "(@)((?:\\w+\\s*)+)",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#transition"
+						}
+					]
+				},
+				"2": {
+					"name": "keyword.control.block.kind.ng"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#blockExpression"
+				},
+				{
+					"include": "#blockBody"
+				}
+			],
+			"contentName": "control.block.ng",
+			"end": "(?<=\\})"
+		},
+		"blockExpression": {
+			"begin": "\\(",
+			"beginCaptures": {
+				"0": {
+					"name": "meta.brace.round.ts"
+				}
+			},
+			"contentName": "control.block.expression.ng",
+			"patterns": [
+				{
+					"include": "source.js"
+				}
+			],
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "meta.brace.round.ts"
+				}
+			}
+		},
+		"blockBody": {
+			"begin": "\\{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.ts"
+				}
+			},
+			"end": "\\}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.ts"
+				}
+			},
+			"contentName": "control.block.body.ng",
+			"patterns": [
+				{
+					"include": "text.html.derivative"
+				},
+				{
+					"include": "template.ng"
+				}
+			]
+		}
+	}
+}

--- a/grammars/angular/syntaxes/template.json
+++ b/grammars/angular/syntaxes/template.json
@@ -3,6 +3,9 @@
 	"injectionSelector": "L:text.html -comment",
 	"patterns": [
 		{
+			"include": "template.blocks.ng"
+		},
+		{
 			"include": "#interpolation"
 		},
 		{

--- a/grammars/angular/syntaxes/template.json
+++ b/grammars/angular/syntaxes/template.json
@@ -1,0 +1,195 @@
+{
+	"scopeName": "template.ng",
+	"injectionSelector": "L:text.html -comment",
+	"patterns": [
+		{
+			"include": "#interpolation"
+		},
+		{
+			"include": "#propertyBinding"
+		},
+		{
+			"include": "#eventBinding"
+		},
+		{
+			"include": "#twoWayBinding"
+		},
+		{
+			"include": "#templateBinding"
+		}
+	],
+	"repository": {
+		"interpolation": {
+			"begin": "{{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.ts"
+				}
+			},
+			"end": "}}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.ts"
+				}
+			},
+			"contentName": "expression.ng",
+			"patterns": [
+				{
+					"include": "expression.ng"
+				}
+			]
+		},
+		"propertyBinding": {
+			"begin": "(\\[\\s*@?[-_a-zA-Z0-9.$]*%?\\s*])(=)([\"'])",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.other.attribute-name.html entity.other.ng-binding-name.property.html",
+					"patterns": [
+						{
+							"include": "#bindingKey"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.key-value.html"
+				},
+				"3": {
+					"name": "string.quoted.html punctuation.definition.string.begin.html"
+				}
+			},
+			"end": "\\3",
+			"endCaptures": {
+				"0": {
+					"name": "string.quoted.html punctuation.definition.string.end.html"
+				}
+			},
+			"name": "meta.ng-binding.property.html",
+			"contentName": "expression.ng",
+			"patterns": [
+				{
+					"include": "expression.ng"
+				}
+			]
+		},
+		"eventBinding": {
+			"begin": "(\\(\\s*@?[-_a-zA-Z0-9.$]*\\s*\\))(=)([\"'])",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.other.attribute-name.html entity.other.ng-binding-name.event.html",
+					"patterns": [
+						{
+							"include": "#bindingKey"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.key-value.html"
+				},
+				"3": {
+					"name": "string.quoted.html punctuation.definition.string.begin.html"
+				}
+			},
+			"end": "\\3",
+			"endCaptures": {
+				"0": {
+					"name": "string.quoted.html punctuation.definition.string.end.html"
+				}
+			},
+			"name": "meta.ng-binding.event.html",
+			"contentName": "expression.ng",
+			"patterns": [
+				{
+					"include": "expression.ng"
+				}
+			]
+		},
+		"twoWayBinding": {
+			"begin": "(\\[\\s*\\(\\s*@?[-_a-zA-Z0-9.$]*\\s*\\)\\s*\\])(=)([\"'])",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html",
+					"patterns": [
+						{
+							"include": "#bindingKey"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.key-value.html"
+				},
+				"3": {
+					"name": "string.quoted.html punctuation.definition.string.begin.html"
+				}
+			},
+			"end": "\\3",
+			"endCaptures": {
+				"0": {
+					"name": "string.quoted.html punctuation.definition.string.end.html"
+				}
+			},
+			"name": "meta.ng-binding.two-way.html",
+			"contentName": "expression.ng",
+			"patterns": [
+				{
+					"include": "expression.ng"
+				}
+			]
+		},
+		"templateBinding": {
+			"begin": "(\\*[-_a-zA-Z0-9.$]*)(=)([\"'])",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.other.attribute-name.html entity.other.ng-binding-name.template.html",
+					"patterns": [
+						{
+							"include": "#bindingKey"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.key-value.html"
+				},
+				"3": {
+					"name": "string.quoted.html punctuation.definition.string.begin.html"
+				}
+			},
+			"end": "\\3",
+			"endCaptures": {
+				"0": {
+					"name": "string.quoted.html punctuation.definition.string.end.html"
+				}
+			},
+			"name": "meta.ng-binding.template.html",
+			"contentName": "expression.ng",
+			"patterns": [
+				{
+					"include": "expression.ng"
+				}
+			]
+		},
+		"bindingKey": {
+			"patterns": [
+				{
+					"match": "([\\[\\(]{1,2}|\\*)(?:\\s*)(@?[-_a-zA-Z0-9.$]*%?)(?:\\s*)([\\]\\)]{1,2})?",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.ng-binding-name.begin.html"
+						},
+						"2": {
+							"name": "entity.other.ng-binding-name.$2.html",
+							"patterns": [
+								{
+									"match": "\\.",
+									"name": "punctuation.accessor.html"
+								}
+							]
+						},
+						"3": {
+							"name": "punctuation.definition.ng-binding-name.end.html"
+						}
+					}
+				}
+			]
+		}
+	}
+}

--- a/grammars/grammars.json
+++ b/grammars/grammars.json
@@ -589,6 +589,61 @@
 				"base": "python",
 				"file": "MagicRegExp.tmLanguage.json"
 			}
+		},
+		{
+			"scopeName": "inline-template.ng",
+			"grammar": {
+				"base": "angular",
+				"file": "inline-template.json"
+			},
+			"injectTo": ["source.ts"],
+			"embeddedLanguages": {
+				"text.html": "html",
+				"source.css": "css",
+				"source.js": "javascript"
+			}
+		},
+		{
+			"scopeName": "inline-styles.ng",
+			"grammar": {
+				"base": "angular",
+				"file": "inline-styles.json"
+			},
+			"injectTo": ["source.ts"],
+			"embeddedLanguages": {
+				"source.css": "css"
+			}
+		},
+		{
+			"scopeName": "template.ng",
+			"grammar": {
+				"base": "angular",
+				"file": "template.json"
+			},
+			"injectTo": ["text.html.derivative", "source.ts"],
+			"embeddedLanguages": {
+				"text.html": "html",
+				"source.css": "css"
+			}
+		},
+		{
+			"scopeName": "template.blocks.ng",
+			"grammar": {
+				"base": "angular",
+				"file": "template-blocks.json"
+			},
+			"injectTo": ["text.html.derivative", "source.ts"],
+			"embeddedLanguages": {
+				"text.html": "html",
+				"source.js": "javascript"
+			}
+		},
+		{
+			"scopeName": "expression.ng",
+			"grammar": {
+				"base": "angular",
+				"file": "expression.json"
+			}
 		}
 	]
 }

--- a/grammars/grammars.json
+++ b/grammars/grammars.json
@@ -620,11 +620,7 @@
 				"base": "angular",
 				"file": "template.json"
 			},
-			"injectTo": ["text.html.derivative", "source.ts"],
-			"embeddedLanguages": {
-				"text.html": "html",
-				"source.css": "css"
-			}
+			"injectTo": ["text.html.derivative"]
 		},
 		{
 			"scopeName": "template.blocks.ng",
@@ -632,11 +628,7 @@
 				"base": "angular",
 				"file": "template-blocks.json"
 			},
-			"injectTo": ["text.html.derivative", "source.ts"],
-			"embeddedLanguages": {
-				"text.html": "html",
-				"source.js": "javascript"
-			}
+			"injectTo": ["text.html.derivative"]
 		},
 		{
 			"scopeName": "expression.ng",


### PR DESCRIPTION
This PR adds TextMate grammars for syntaxes used by Angular, based on the latest syntaxes from https://github.com/angular/vscode-ng-language-service, including the [Angular 17 control flow syntax](https://blog.angular.io/meet-angulars-new-control-flow-a02c6eee7843).

Apparently there is no Angular templating _language_, only Angular-specific _grammars_ for syntaxes embedded in other languages, especially in TypeScript (provides highlighting for template strings in TypeScript files) and in HTML. This PR adds 5 JSON grammars.

In my tests, when plugged into the StackBlitz classic editor, this leads to most projects (including non-Angular projects) fetching those 5 JSON grammars, as long as the project has a TypeScript or HTML file.

I’m a bit wary of those extra requests for all projects, but maybe that's an issue that we want to address separately.