### PR TITLE
chore(ci): update Node versions used in CI test

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,7 +1,10 @@
 name: CI
+
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches: [main]
+
 jobs:
   test:
     name: Node.js ${{ matrix.node-version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,13 +9,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version:
-          - 14
-          - 12
-          - 10
+        node-version: [20, 18]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install


### PR DESCRIPTION
Our current GitHub Actions config runs `npm test`:

- On Node 10, 12 and 14;
- Twice for pull requests, because the `on: [push, pull_request]` config matches pull requests *twice* (it's a pull request, and it's a push on a branch).

This PR updates our GitHub Actions CI config:

- to use the latest versions of `actions/checkout` and `actions/setup-node`;
- to only run jobs on `push` for the `main` branch, instead of all branches;
- to run tests with Node 20 and 18 (instead of 10, 12 and 14).

For the Node versions, we could also use values like `lts` and `lts/-1`, but I’m not finding conclusive docs on whether the `lts/-N` syntax works. I’m also not sure we want to auto-update like that.

I also excluded Node 16 because it's EOL, but I’m open to include it if we want to test the last 3 LTS versions.