### PR TITLE
fix(angular): Make block syntax grammars more restrictive

### DIFF
--- a/grammars/angular/syntaxes/template-blocks.json
+++ b/grammars/angular/syntaxes/template-blocks.json
@@ -12,7 +12,7 @@
 			"name": "keyword.control.block.transition.ng"
 		},
 		"block": {
-			"begin": "(@)((?:\\w+\\s*)+)",
+			"begin": "(@)((?:\\w+\\s*)+)(?=\\(|\\{)",
 			"beginCaptures": {
 				"1": {
 					"patterns": [
@@ -46,7 +46,7 @@
 			"contentName": "control.block.expression.ng",
 			"patterns": [
 				{
-					"include": "source.js"
+					"include": "expression.ng"
 				}
 			],
 			"end": "\\)",


### PR DESCRIPTION
This commit includes the following upstream fixes: https://github.com/angular/vscode-ng-language-service/commit/e17fc5c3548fcb2b174a62741b1b2914eaeb7d35 https://github.com/angular/vscode-ng-language-service/commit/075047ae31fefddc77364b466484dc825f192cec