### PR TITLE
fix(angular): Exclude template block grammars in CSS and JS contexts

### DIFF
--- a/grammars/angular/syntaxes/template-blocks.json
+++ b/grammars/angular/syntaxes/template-blocks.json
@@ -1,6 +1,6 @@
 {
 	"scopeName": "template.blocks.ng",
-	"injectionSelector": "L:text.html -comment -expression.ng -meta.tag",
+	"injectionSelector": "L:text.html -comment -expression.ng -meta.tag -source.css -source.js",
 	"patterns": [
 		{
 			"include": "#block"


### PR DESCRIPTION
This commit ensures the Angular template block syntax highlighting does not apply in in the HTML language where it has transitioned to embedded `css` or `js` (i.e. in `script` tags).