### PR TITLE
fix(typescript): add support for mts and cts extensions

### DIFF
--- a/grammars/grammars.json
+++ b/grammars/grammars.json
@@ -42,7 +42,7 @@
 		{
 			"language": "typescript",
 			"scopeName": "source.ts",
-			"extensions": [".ts"],
+			"extensions": [".ts", ".mts", ".cts"],
 			"grammar": "TypeScript.tmLanguage.json",
 			"tokenTypes": {
 				"entity.name.type.instance.jsdoc": "other",


### PR DESCRIPTION
I noticed that we didn't support the `.mts` and `.cts` extensions yet. Meaning that StackBlitz renders those file as plain text.

With this change, the proper grammar is loaded and it will also trigger the language service.

https://www.typescriptlang.org/docs/handbook/modules/reference.html#module-format-detection